### PR TITLE
Improve function call to __next__(self) for python2.

### DIFF
--- a/lizard_connector/connector.py
+++ b/lizard_connector/connector.py
@@ -142,7 +142,7 @@ class Connector(object):
 
     def next(self):
         """The next function for Python 2."""
-        return __next__()
+        return self.__next__()
 
     @property
     def use_header(self):


### PR DESCRIPTION
I've noticed that the function call to \_\_next\_\_() didn't function properly for Python2.
Solved if by calling self.\_\_next\_\_() instead.