### PR TITLE
Fix max results for paginated Endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog of lizard-connector
 0.4 (unreleased)
 ----------------
 
+- Fix max result count for paginated Endpoint.
+
 - Compatible with python 2.7.
 
 

--- a/lizard_connector/connector.py
+++ b/lizard_connector/connector.py
@@ -58,6 +58,12 @@ class Connector(object):
         self.username = username
         self.password = password
 
+    def too_many_results(self, count):
+        """We don't want to download too much, but it's no problem if we
+        download page by page.
+        """
+        return self.all_pages and (count > self.max_results)
+
     def get(self, url):
         """
         GET a json from the api.
@@ -71,7 +77,7 @@ class Connector(object):
         json_ = self.perform_request(url)
         self.count = json_.get('count')
         count = self.count if self.count else 0
-        if count > self.max_results:
+        if self.too_many_results(count):
             raise LizardApiTooManyResults(
                 'Too many results: {} found, while max {} are accepted'.format(
                     count, self.max_results)
@@ -168,7 +174,6 @@ class Connector(object):
 
 
 class Endpoint(Connector):
-    max_results = 1000
 
     def __init__(self, endpoint, base="https://demo.lizard.net", **kwargs):
         """


### PR DESCRIPTION
I think we want to ignore `max_results` when we're in paginated mode, which should be indicated by `all_pages=False`.