### PR TITLE
Add explicit py2/3 imports to fix python-future problems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-connector
 0.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add explicit py2/3 imports to mitigate problems with the ``future`` library.
 
 
 0.5 (2017-10-16)

--- a/lizard_connector/connector.py
+++ b/lizard_connector/connector.py
@@ -17,22 +17,25 @@ from __future__ import unicode_literals
 from __future__ import generators
 
 import json
-
 import time
+import sys
 from threading import Thread, RLock
 
-try:
-    from urllib.parse import urlencode
-    from urllib.parse import urljoin
-    import urllib.request as urllib_request
-    from urllib.request import urlopen
-except ImportError:
+import lizard_connector.queries
+
+if sys.version_info.major < 3:
+    # py2
     from urllib import urlencode
     from urlparse import urljoin
     import urllib2 as urllib_request
     from urllib2 import urlopen
+else:
+    # py3
+    from urllib.parse import urlencode
+    from urllib.parse import urljoin
+    import urllib.request as urllib_request
+    from urllib.request import urlopen
 
-import lizard_connector.queries
 
 ASYNC_POLL_TIME = 1
 ASYNC_POLL_TIME_INCREASE = 1.5

--- a/lizard_connector/queries.py
+++ b/lizard_connector/queries.py
@@ -2,13 +2,17 @@
 from __future__ import unicode_literals
 
 import datetime
-try:
-    import urllib.parse as urlparse
-    unicode = str
-except ImportError:
-    import urlparse
+import sys
 
 from lizard_connector import jsdatetime
+
+if sys.version_info.major < 3:
+    # py2
+    import urlparse
+else:
+    # py3
+    import urllib.parse as urlparse
+    unicode = str
 
 
 class LizardApiImproperQueryError(Exception):


### PR DESCRIPTION
fixes https://github.com/lizardsystem/lizard-connector/issues/17
This is a workaround for problems caused by `python-future`