### PR TITLE
Added deprecation warning when using v2 API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-connector
 0.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added FutureWarnings when using the v2 API (default is V3)
 
 
 0.7.1 (2018-04-17)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 lizard-connector
 ================
 
+:warning: **Lizard API version 2 will deprecate on January 31th 2021, please switch to the default API version 3**
+
+This can be done by either omitting the version parameter when creating a Client instance, or creating a Client instance with version 3 specified:
+
+```    
+    from lizard_connector import Client
+    cli = Client(version=3)
+```
+
 Introduction
 ------------
 
@@ -24,7 +33,7 @@ Example usage
 An example jupyter notebook can be found `Example_EN.ipynb` or in Dutch:
 `Voorbeeld_NL.ipynb`.
 
-Use one endpoints https://demo.lizard.net/api/v2 in Python with the Endpoint
+Use one endpoints https://demo.lizard.net/api/v3 in Python with the Endpoint
 class:
 
 ```

--- a/lizard_connector/connector.py
+++ b/lizard_connector/connector.py
@@ -17,6 +17,7 @@ import json
 import getpass
 import time
 import sys
+import warnings
 from threading import Thread, RLock
 
 import lizard_connector.queries
@@ -242,8 +243,8 @@ class Endpoint(Connector):
         """
 
         # API Deprecation warning
-        # if int(version) == 2:
-        #     print("V2 deprecation warning")
+        if version == 2:
+            warnings.warn("Lizard Connector endpoint: API version 2 will deprecate on \33[32mJanuary 31th 2021\033[0m. Please switch to the default API version 3.", FutureWarning)
 
         super(Endpoint, self).__init__(**kwargs)
         self.endpoint = endpoint
@@ -477,27 +478,7 @@ class Client(Connector):
         self.api_version = version
         # API Deprecation warning
         if self.api_version == 2:
-            depracationWarning ="""
-\033[91m============================================================\033[0m
-\033[91m============================================================\033[0m
-                                    
-            \33[33mLizard API V2 deprecation warning:\033[0m
-                                    
-API version 2 will deprecate on \33[32mJanuary 31th 2021\033[0m.
-Please switch to the default API version 3.
-
-This can be done by either omitting the version
-parameter when creating a Client instance,
-or creating a Client instance with version 3 specified:
-
-    from lizard_connector import Client
-    cli = Client(version=3)
-
-\033[91m============================================================\033[0m
-\033[91m============================================================\033[0m                                    
-"""
-
-            print(depracationWarning)
+            warnings.warn("Lizard Connector: API version 2 will deprecate on \33[32mJanuary 31th 2021\033[0m. Please switch to the default API version 3.", FutureWarning, stacklevel=2)
 
         if username is not None:
             kwargs.update({

--- a/lizard_connector/connector.py
+++ b/lizard_connector/connector.py
@@ -240,6 +240,11 @@ class Endpoint(Connector):
                 as a data detail endpoint of the form:
                     `../api/{version}/{endpoint}/{uuid}/data`
         """
+
+        # API Deprecation warning
+        # if int(version) == 2:
+        #     print("V2 deprecation warning")
+
         super(Endpoint, self).__init__(**kwargs)
         self.endpoint = endpoint
         base = base.strip(r'/')
@@ -470,6 +475,30 @@ class Client(Connector):
                 each endpoint parse call.
         """
         self.api_version = version
+        # API Deprecation warning
+        if self.api_version == 2:
+            depracationWarning ="""
+\033[91m============================================================\033[0m
+\033[91m============================================================\033[0m
+                                    
+            \33[33mLizard API V2 deprecation warning:\033[0m
+                                    
+API version 2 will deprecate on \33[32mJanuary 31th 2021\033[0m.
+Please switch to the default API version 3.
+
+This can be done by either omitting the version
+parameter when creating a Client instance,
+or creating a Client instance with version 3 specified:
+
+    from lizard_connector import Client
+    cli = Client(version=3)
+
+\033[91m============================================================\033[0m
+\033[91m============================================================\033[0m                                    
+"""
+
+            print(depracationWarning)
+
         if username is not None:
             kwargs.update({
                 "username": username,


### PR DESCRIPTION
![Screenshot from 2020-12-11 11-51-29](https://user-images.githubusercontent.com/11943796/101908859-fd084480-3bbc-11eb-81bd-ddb7d9713017.png)

Added this deprecation warning

The default API for the lizard-connector is V3 so no need to shut the whole thing down just yet