### PR TITLE
Remove remaining mentions of API v2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-connector
 0.8 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Removed mentions of v2 API from docs.
 
 
 0.7.2 (2020-12-17)

--- a/lizard_connector/connector.py
+++ b/lizard_connector/connector.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """
-Connector to Lizard api (e.g. https://demo.lizard.net/api/v2) for python.
+Connector to Lizard api for python.
 
 Includes:
 - A Lizard Client that allows querying an API of one of the Lizard portals.
@@ -117,7 +117,7 @@ class Connector(object):
 
         Args:
             url (str): full query url: should be of the form:
-                       [base_url]/api/v2/[endpoint]/?[query_key]=[query_value]&
+                       [base_url]/api/v3/[endpoint]/?[query_key]=[query_value]&
                            ...
             data (dict): data in a list or dictionary format.
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ tests_require = [
 
 setup(name='lizard-connector',
       version=version,
-      description="A connector to connect to the Lizard-API "
-                  "(https://demo.lizard.net/api/v2/) with Python.",
+      description="A connector to connect to the Lizard-API with Python.",
       long_description=long_description,
       # Get strings from http://www.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[


### PR DESCRIPTION
I noticed that API v2 is still in the project's title. A bit confusing considering that we are deprecating that version.

So I did a grep on v2 and now it is completely gone from the repo.